### PR TITLE
[FIX]: Fixed frameRate function

### DIFF
--- a/ffprobe/ffprobe.py
+++ b/ffprobe/ffprobe.py
@@ -333,11 +333,22 @@ class FFStream(object):
         f = 0.0
         if 'codec_type' in self.__dict__:
             if str(self.__dict__['codec_type']) == 'video':
-                if 'nb_frames' in self.__dict__ and 'duration' in self.__dict__:
-                    try:
-                        f = int(self.__dict__['nb_frames']/self.__dict__['duration'])
-                    except Exception as e:
-                        pass
+                try:
+                    if 'r_frame_rate' in self.__dict__:
+                        values = self.__dict__['r_frame_rate']
+                        values = values.split('/')
+                        try:
+                            f = float(values[0])/float(values[1])
+                        except Exception as e:
+                            pass
+                    else:
+                        if 'nb_frames' in self.__dict__ and 'duration' in self.__dict__:
+                            try:
+                                f = float(self.__dict__['nb_frames'])/float(self.__dict__['duration'])
+                            except Exception as e:
+                                pass
+                except Exception as e:
+                    pass
         return f
 
 def printMeta(path):


### PR DESCRIPTION
Fixed frameRate function to calculate frame rate of videos with two alternatives

Now using 'r_frame_rate' values splitting it in two values and make the calculations and fixed error with 'nb_frames' and 'duration' not getting converted to float as it should be